### PR TITLE
Fix visualizer imports

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -9,8 +9,6 @@
 <body>
   <canvas id="canvas"></canvas>
   <button id="start-btn">Start</button>
-  <script type="module">
-    import '@/main.js';
-  </script>
+  <script type="module" src="../src/main.js"></script>
 </body>
 </html>

--- a/src/canvasPainter.js
+++ b/src/canvasPainter.js
@@ -1,4 +1,4 @@
-import { mapRange } from '@/utils.js';
+import { mapRange } from './utils.js';
 
 /**
  * Renders visuals on a canvas using Perlin noise and fused parameters.

--- a/src/fusionLogic.js
+++ b/src/fusionLogic.js
@@ -1,4 +1,4 @@
-import { mapRange } from '@/utils.js';
+import { mapRange } from './utils.js';
 
 /**
  * Fuses audio and motion data into visual parameters.

--- a/src/main.js
+++ b/src/main.js
@@ -1,8 +1,8 @@
-import { AudioProcessor } from '@/audioProcessor.js';
-import { MotionHandler } from '@/motionHandler.js';
-import { FusionLogic } from '@/fusionLogic.js';
-import { CanvasPainter } from '@/canvasPainter.js';
-import { Perlin } from '@/perlin.js';
+import { AudioProcessor } from './audioProcessor.js';
+import { MotionHandler } from './motionHandler.js';
+import { FusionLogic } from './fusionLogic.js';
+import { CanvasPainter } from './canvasPainter.js';
+import { Perlin } from './perlin.js';
 
 window.addEventListener('load', () => {
   const startBtn = document.getElementById('start-btn');


### PR DESCRIPTION
## Summary
- use relative paths for music painter modules
- load main script via standard module import

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_683e6cc3ad0c8323b5d29e49bcaa5387